### PR TITLE
Støtte for data-dokumenter og lenke utenfor brev i data-dokument

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <sdp-shared.version>2.5-RC1</sdp-shared.version>
+        <sdp-shared.version>2.5</sdp-shared.version>
 
         <spring.version>4.3.7.RELEASE</spring.version>
         <spring.ws.version>2.3.0.RELEASE</spring.ws.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <sdp-shared.version>2.4</sdp-shared.version>
+        <sdp-shared.version>2.5-RC1</sdp-shared.version>
 
         <spring.version>4.3.7.RELEASE</spring.version>
         <spring.ws.version>2.3.0.RELEASE</spring.ws.version>

--- a/src/main/java/no/difi/sdp/client2/asice/CreateASiCE.java
+++ b/src/main/java/no/difi/sdp/client2/asice/CreateASiCE.java
@@ -15,8 +15,10 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
 
 public class CreateASiCE {
 
@@ -39,10 +41,10 @@ public class CreateASiCE {
         log.info("Creating ASiC-E manifest");
         Manifest manifest = createManifest.createManifest(forsendelse);
 
-        List<AsicEAttachable> files = new ArrayList<AsicEAttachable>();
-        files.add(forsendelse.getDokumentpakke().getHoveddokument());
-        files.addAll(forsendelse.getDokumentpakke().getVedlegg());
-        files.addAll(forsendelse.getDokumentpakke().getDataDokumenter());
+        List<AsicEAttachable> files = Stream.concat(
+                forsendelse.getDokumentpakke().alleDokumenter(),
+                forsendelse.getDokumentpakke().alleDataDokumenter()
+        ).collect(toList());
         files.add(manifest);
 
         // Lag signatur over alle filene i pakka

--- a/src/main/java/no/difi/sdp/client2/asice/CreateASiCE.java
+++ b/src/main/java/no/difi/sdp/client2/asice/CreateASiCE.java
@@ -42,6 +42,7 @@ public class CreateASiCE {
         List<AsicEAttachable> files = new ArrayList<AsicEAttachable>();
         files.add(forsendelse.getDokumentpakke().getHoveddokument());
         files.addAll(forsendelse.getDokumentpakke().getVedlegg());
+        files.addAll(forsendelse.getDokumentpakke().getDataDokumenter());
         files.add(manifest);
 
         // Lag signatur over alle filene i pakka

--- a/src/main/java/no/difi/sdp/client2/domain/Dokument.java
+++ b/src/main/java/no/difi/sdp/client2/domain/Dokument.java
@@ -1,6 +1,7 @@
 package no.difi.sdp.client2.domain;
 
 import no.difi.sdp.client2.asice.AsicEAttachable;
+import no.difi.sdp.client2.domain.utvidelser.DataDokument;
 import org.apache.commons.io.IOUtils;
 
 import java.io.File;
@@ -8,6 +9,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 public class Dokument implements AsicEAttachable {
 
@@ -15,6 +17,7 @@ public class Dokument implements AsicEAttachable {
     private String filnavn;
     private byte[] dokument;
     private String mimeType = "application/pdf";
+    private Optional<DataDokument> dataDokument = Optional.empty();
 
     private Dokument(String tittel, String filnavn, byte[] dokument) {
         this.tittel = tittel;
@@ -43,6 +46,10 @@ public class Dokument implements AsicEAttachable {
 
     public String getTittel() {
         return tittel;
+    }
+
+    public Optional<DataDokument> getDataDokument() {
+        return dataDokument;
     }
 
     /**
@@ -98,6 +105,11 @@ public class Dokument implements AsicEAttachable {
          */
         public Builder mimeType(String mimeType) {
             target.mimeType = mimeType;
+            return this;
+        }
+
+        public Builder dataDokument(DataDokument dataDokument) {
+            target.dataDokument = Optional.of(dataDokument);
             return this;
         }
 

--- a/src/main/java/no/difi/sdp/client2/domain/Dokumentpakke.java
+++ b/src/main/java/no/difi/sdp/client2/domain/Dokumentpakke.java
@@ -1,8 +1,11 @@
 package no.difi.sdp.client2.domain;
 
+import no.difi.sdp.client2.domain.utvidelser.DataDokument;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Arrays.asList;
 
@@ -23,6 +26,13 @@ public class Dokumentpakke {
         return vedlegg;
     }
 
+    public List<DataDokument> getDataDokumenter() {
+        List<DataDokument> dataDokumenter = new ArrayList<>();
+        getHoveddokument().getDataDokument().ifPresent(dataDokumenter::add);
+        getVedlegg().stream().map(Dokument::getDataDokument).filter(Optional::isPresent).map(Optional::get).forEach(dataDokumenter::add);
+        return dataDokumenter;
+    }
+
     public static Builder builder(Dokument hoveddokument) {
         return new Builder(hoveddokument);
     }
@@ -37,7 +47,7 @@ public class Dokumentpakke {
         }
 
         public Builder vedlegg(List<Dokument> vedlegg) {
-            target.vedlegg = new ArrayList<Dokument>(vedlegg);
+            target.vedlegg = new ArrayList<>(vedlegg);
             return this;
         }
 

--- a/src/main/java/no/difi/sdp/client2/domain/Dokumentpakke.java
+++ b/src/main/java/no/difi/sdp/client2/domain/Dokumentpakke.java
@@ -5,7 +5,7 @@ import no.difi.sdp.client2.domain.utvidelser.DataDokument;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 
@@ -26,11 +26,12 @@ public class Dokumentpakke {
         return vedlegg;
     }
 
-    public List<DataDokument> getDataDokumenter() {
-        List<DataDokument> dataDokumenter = new ArrayList<>();
-        getHoveddokument().getDataDokument().ifPresent(dataDokumenter::add);
-        getVedlegg().stream().map(Dokument::getDataDokument).filter(Optional::isPresent).map(Optional::get).forEach(dataDokumenter::add);
-        return dataDokumenter;
+    public Stream<Dokument> alleDokumenter() {
+        return Stream.concat(Stream.of(this.hoveddokument), this.vedlegg.stream());
+    }
+
+    public Stream<DataDokument> alleDataDokumenter() {
+        return alleDokumenter().map(Dokument::getDataDokument).flatMap(d -> d.map(Stream::of).orElseGet(Stream::empty));
     }
 
     public static Builder builder(Dokument hoveddokument) {

--- a/src/main/java/no/difi/sdp/client2/domain/utvidelser/DataDokument.java
+++ b/src/main/java/no/difi/sdp/client2/domain/utvidelser/DataDokument.java
@@ -1,0 +1,66 @@
+package no.difi.sdp.client2.domain.utvidelser;
+
+import no.difi.sdp.client2.asice.AsicEAttachable;
+import no.difi.sdp.client2.domain.exceptions.SendException.AntattSkyldig;
+import no.difi.sdp.client2.domain.exceptions.XmlValideringException;
+import org.springframework.core.io.Resource;
+import org.springframework.oxm.MarshallingFailureException;
+import org.springframework.oxm.jaxb.Jaxb2Marshaller;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayOutputStream;
+
+import static no.difi.sdp.client2.domain.utvidelser.Marshalling.getMarshaller;
+
+public abstract class DataDokument implements AsicEAttachable {
+
+    private final String filnavn;
+    private final String mimeType;
+    private final Jaxb2Marshaller marshaller;
+
+    private byte[] bytes = null;
+
+
+    DataDokument(String filnavn, String mimeType, Class<?> type, Resource schema) {
+        this.filnavn = filnavn;
+        this.mimeType = mimeType;
+        this.marshaller = getMarshaller(schema, type);
+    }
+
+    abstract Object jaxbObject();
+
+    @Override
+    public String getFileName() {
+        return filnavn;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        if (this.bytes == null) {
+            this.bytes = asBytes();
+        }
+        return this.bytes;
+    }
+
+    @Override
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    private byte[] asBytes() {
+        ByteArrayOutputStream dataStream = new ByteArrayOutputStream();
+        try {
+            marshaller.marshal(jaxbObject(), new StreamResult(dataStream));
+        } catch (MarshallingFailureException e) {
+            if (e.getMostSpecificCause() instanceof SAXParseException) {
+                throw new XmlValideringException("Kunne ikke validere generert XML for '" + filnavn + "'. Sjekk at alle påkrevde input er satt og ikke er null",
+                        AntattSkyldig.KLIENT, (SAXParseException) e.getMostSpecificCause());
+            }
+            throw e;
+        }
+        return dataStream.toByteArray();
+    }
+
+
+}

--- a/src/main/java/no/difi/sdp/client2/domain/utvidelser/Lenke.java
+++ b/src/main/java/no/difi/sdp/client2/domain/utvidelser/Lenke.java
@@ -1,0 +1,80 @@
+package no.difi.sdp.client2.domain.utvidelser;
+
+
+import no.difi.begrep.sdp.utvidelser.lenke.SDPLenke;
+import no.difi.begrep.sdp.utvidelser.lenke.SDPLenkeBeskrivelseTekst;
+import no.difi.begrep.sdp.utvidelser.lenke.SDPLenkeKnappTekst;
+
+import java.time.ZonedDateTime;
+
+import static no.digipost.api.xml.Schemas.LENKE_SCHEMA;
+
+public final class Lenke extends DataDokument {
+
+    private final String url;
+    private String beskrivelse;
+    private String knappTekst;
+    private String spraakkode = "NO";
+    private ZonedDateTime frist;
+
+
+    private Lenke(String filnavn, String url) {
+        super(filnavn, "application/vnd.difi.dpi.lenke+xml", SDPLenke.class, LENKE_SCHEMA);
+        this.url = url;
+    }
+
+    @Override
+    SDPLenke jaxbObject() {
+        return new SDPLenke(
+                url,
+                beskrivelse != null ? new SDPLenkeBeskrivelseTekst(beskrivelse, spraakkode) : null,
+                knappTekst != null ? new SDPLenkeKnappTekst(knappTekst, spraakkode) : null,
+                frist
+        );
+    }
+
+    public static Builder builder(String filnavn, String url) {
+        return new Builder(filnavn, url);
+    }
+
+    public static final class Builder {
+
+        private final Lenke target;
+        private boolean built = false;
+
+        private Builder(String filnavn, String url) {
+            target = new Lenke(filnavn, url);
+        }
+
+        public Builder beskrivelse(String beskrivelse) {
+            target.beskrivelse = beskrivelse;
+            return this;
+        }
+
+        public Builder knappTekst(String knappTekst) {
+            target.knappTekst = knappTekst;
+            return this;
+        }
+
+        /**
+         * Språkkode i henhold til ISO-639-1 (2 bokstaver). Brukes til å informere postkassen om hvilket språk som benyttes.
+         * <p>
+         * Standard er NO.
+         */
+        public Builder spraakkode(String spraakkode) {
+            target.spraakkode = spraakkode;
+            return this;
+        }
+
+        public Builder frist(ZonedDateTime frist) {
+            target.frist = frist;
+            return this;
+        }
+
+        public Lenke build() {
+            if (built) throw new IllegalStateException("Can't build twice");
+            built = true;
+            return target;
+        }
+    }
+}

--- a/src/main/java/no/difi/sdp/client2/domain/utvidelser/Lenke.java
+++ b/src/main/java/no/difi/sdp/client2/domain/utvidelser/Lenke.java
@@ -13,7 +13,7 @@ public final class Lenke extends DataDokument {
 
     private final String url;
     private String beskrivelse;
-    private String knappTekst;
+    private String knappetekst;
     private String spraakkode = "NO";
     private ZonedDateTime frist;
 
@@ -28,7 +28,7 @@ public final class Lenke extends DataDokument {
         return new SDPLenke(
                 url,
                 beskrivelse != null ? new SDPLenkeBeskrivelseTekst(beskrivelse, spraakkode) : null,
-                knappTekst != null ? new SDPLenkeKnappTekst(knappTekst, spraakkode) : null,
+                knappetekst != null ? new SDPLenkeKnappTekst(knappetekst, spraakkode) : null,
                 frist
         );
     }
@@ -51,8 +51,8 @@ public final class Lenke extends DataDokument {
             return this;
         }
 
-        public Builder knappTekst(String knappTekst) {
-            target.knappTekst = knappTekst;
+        public Builder knappetekst(String knappetekst) {
+            target.knappetekst = knappetekst;
             return this;
         }
 

--- a/src/main/java/no/difi/sdp/client2/domain/utvidelser/Marshalling.java
+++ b/src/main/java/no/difi/sdp/client2/domain/utvidelser/Marshalling.java
@@ -1,0 +1,28 @@
+package no.difi.sdp.client2.domain.utvidelser;
+
+import no.difi.sdp.client2.domain.exceptions.KonfigurasjonException;
+import org.springframework.core.io.Resource;
+import org.springframework.oxm.jaxb.Jaxb2Marshaller;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+final class Marshalling {
+
+    private static ConcurrentMap<Resource, Jaxb2Marshaller> marshallers = new ConcurrentHashMap<>();
+
+    static Jaxb2Marshaller getMarshaller(Resource schema, Class<?> type) {
+        return marshallers.computeIfAbsent(schema, schemaResource -> {
+            Jaxb2Marshaller marshaller = new Jaxb2Marshaller();
+            marshaller.setPackagesToScan(type.getPackage().getName());
+            marshaller.setSchema(schemaResource);
+            try {
+                marshaller.afterPropertiesSet();
+            } catch (Exception e) {
+                throw new KonfigurasjonException("Kunne ikke sette opp Jaxb marshaller", e);
+            }
+            return marshaller;
+        });
+    }
+
+}

--- a/src/main/java/no/difi/sdp/client2/internal/SDPBuilder.java
+++ b/src/main/java/no/difi/sdp/client2/internal/SDPBuilder.java
@@ -4,6 +4,7 @@ import no.difi.begrep.sdp.schema_v10.SDPAvsender;
 import no.difi.begrep.sdp.schema_v10.SDPDigitalPost;
 import no.difi.begrep.sdp.schema_v10.SDPDigitalPostInfo;
 import no.difi.begrep.sdp.schema_v10.SDPDokument;
+import no.difi.begrep.sdp.schema_v10.SDPDokumentData;
 import no.difi.begrep.sdp.schema_v10.SDPEpostVarsel;
 import no.difi.begrep.sdp.schema_v10.SDPEpostVarselTekst;
 import no.difi.begrep.sdp.schema_v10.SDPFysiskPostInfo;
@@ -31,6 +32,7 @@ import no.difi.sdp.client2.domain.digital_post.SmsVarsel;
 import no.difi.sdp.client2.domain.fysisk_post.FysiskPost;
 import no.difi.sdp.client2.domain.fysisk_post.KonvoluttAdresse;
 import no.difi.sdp.client2.domain.fysisk_post.KonvoluttAdresse.Type;
+import no.difi.sdp.client2.domain.utvidelser.DataDokument;
 import org.w3.xmldsig.Reference;
 import org.w3.xmldsig.Signature;
 
@@ -81,7 +83,13 @@ public class SDPBuilder {
 
 	private SDPDokument sdpDokument(final Dokument dokument, final String spraakkode) {
         SDPTittel sdpTittel = new SDPTittel(dokument.getTittel(), spraakkode);
-        return new SDPDokument(sdpTittel, dokument.getFilnavn(), dokument.getMimeType());
+        SDPDokumentData sdpDokumentData = dokument.getDataDokument().map(SDPBuilder::sdpDokumentData).orElse(null);
+
+        return new SDPDokument(sdpTittel, sdpDokumentData, dokument.getFilnavn(), dokument.getMimeType());
+    }
+
+    private static SDPDokumentData sdpDokumentData(DataDokument dataDokument) {
+        return new SDPDokumentData(dataDokument.getFileName(), dataDokument.getMimeType());
     }
 
     private SDPMottaker sdpMottaker(final DigitalPost digitalPost) {

--- a/src/test/java/no/difi/sdp/client2/domain/utvidelser/LenkeTest.java
+++ b/src/test/java/no/difi/sdp/client2/domain/utvidelser/LenkeTest.java
@@ -1,0 +1,52 @@
+package no.difi.sdp.client2.domain.utvidelser;
+
+import no.difi.begrep.sdp.utvidelser.lenke.SDPLenke;
+import no.difi.sdp.client2.domain.exceptions.XmlValideringException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class LenkeTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void lenke_med_bare_obligatoriske_felter_satt_oversettes_riktig() {
+        SDPLenke lenke = Lenke.builder("lenke.xml", "https://www.avsender.no").build().jaxbObject();
+        assertThat(lenke.getUrl(), is("https://www.avsender.no"));
+        assertThat(lenke.getBeskrivelse(), nullValue());
+        assertThat(lenke.getKnappTekst(), nullValue());
+        assertThat(lenke.getFrist(), nullValue());
+    }
+
+    @Test
+    public void lenke_med_alle_felter_satt_oversettes_riktig() {
+        SDPLenke lenke = Lenke.builder("lenke.xml", "https://www.avsender.no")
+                .beskrivelse("Beskrivelse")
+                .knappTekst("Knappe-tekst")
+                .frist(ZonedDateTime.of(LocalDateTime.of(2017, 1, 10, 11, 29), ZoneId.of("Europe/Oslo")))
+                .build()
+                .jaxbObject();
+        assertThat(lenke.getUrl(), is("https://www.avsender.no"));
+        assertThat(lenke.getBeskrivelse().getValue(), is("Beskrivelse"));
+        assertThat(lenke.getKnappTekst().getValue(), is("Knappe-tekst"));
+        assertThat(lenke.getFrist(), is(ZonedDateTime.of(LocalDateTime.of(2017, 1, 10, 11, 29), ZoneId.of("Europe/Oslo"))));
+    }
+
+    @Test
+    public void kaster_exception_ved_valideringsfeil() {
+        Lenke lenkeMedUgyldigURL = Lenke.builder("lenke.xml", "ugyldig-url-som-mangler-protokoll.no").build();
+        thrown.expect(XmlValideringException.class);
+        lenkeMedUgyldigURL.getBytes();
+    }
+
+}

--- a/src/test/java/no/difi/sdp/client2/domain/utvidelser/LenkeTest.java
+++ b/src/test/java/no/difi/sdp/client2/domain/utvidelser/LenkeTest.java
@@ -32,13 +32,13 @@ public class LenkeTest {
     public void lenke_med_alle_felter_satt_oversettes_riktig() {
         SDPLenke lenke = Lenke.builder("lenke.xml", "https://www.avsender.no")
                 .beskrivelse("Beskrivelse")
-                .knappTekst("Knappe-tekst")
+                .knappetekst("Knappetekst")
                 .frist(ZonedDateTime.of(LocalDateTime.of(2017, 1, 10, 11, 29), ZoneId.of("Europe/Oslo")))
                 .build()
                 .jaxbObject();
         assertThat(lenke.getUrl(), is("https://www.avsender.no"));
         assertThat(lenke.getBeskrivelse().getValue(), is("Beskrivelse"));
-        assertThat(lenke.getKnappTekst().getValue(), is("Knappe-tekst"));
+        assertThat(lenke.getKnappTekst().getValue(), is("Knappetekst"));
         assertThat(lenke.getFrist(), is(ZonedDateTime.of(LocalDateTime.of(2017, 1, 10, 11, 29), ZoneId.of("Europe/Oslo"))));
     }
 


### PR DESCRIPTION
Et data-dokument er en separat XML-fil som inkluderes i ASiC-E-pakken
og refereres til i et `<data>`-element i manifest-filen. Et dokument
(hoveddokument eller vedlegg) kan ha en slik referanse. Innholdet i
XML-filen er strukturert data som postkasseleverandøren _kan_ bruke til
å berike visningen av dokumentet for innbygger.